### PR TITLE
add TypeBox to add and remove boxed/runtime-typed values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttmap"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Douman <douman@gmx.se>"]
 edition = "2018"
 license = "BSL-1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,8 +256,6 @@ impl TypeBox {
 
     /// Gets the type id of the boxed value.
     pub fn boxed_type_id(&self) -> TypeId {
-        use core::any::Any;
-
         (&*self.0).type_id()
     }
 }

--- a/tests/type_map.rs
+++ b/tests/type_map.rs
@@ -1,5 +1,5 @@
 use std::any::TypeId;
-use ttmap::{ValueBox, TypeMap};
+use ttmap::{TypeMap, ValueBox};
 
 #[test]
 fn check_type_map() {

--- a/tests/type_map.rs
+++ b/tests/type_map.rs
@@ -1,4 +1,5 @@
-use ttmap::TypeMap;
+use std::any::TypeId;
+use ttmap::{TypeBox, TypeMap};
 
 #[test]
 fn check_type_map() {
@@ -40,6 +41,24 @@ fn check_type_map() {
 
     map.clear();
     assert!(map.is_empty());
+}
+
+#[test]
+fn check_type_box() {
+    let mut map = TypeMap::new();
+
+    assert!(map.is_empty());
+    assert_eq!(map.len(), 0);
+
+    assert!(map.insert("test").is_none());
+    assert_eq!(*map.insert_box(TypeBox::new("lolka")).unwrap(), "test");
+    assert_eq!(*map.get::<&'static str>().unwrap(), "lolka");
+
+    let str_box = map.remove_box(TypeId::of::<&'static str>()).unwrap();
+    assert_eq!(map.remove_box(TypeId::of::<&'static str>()), None);
+    assert_eq!(str_box.boxed_type_id(), TypeId::of::<&'static str>());
+    let str_box = str_box.into_inner_downcast::<bool>().unwrap_err();
+    assert_eq!(str_box.into_inner_downcast::<&'static str>().unwrap(), "lolka");
 }
 
 #[test]

--- a/tests/type_map.rs
+++ b/tests/type_map.rs
@@ -51,11 +51,11 @@ fn check_type_box() {
     assert_eq!(map.len(), 0);
 
     assert!(map.insert("test").is_none());
-    assert_eq!(*map.insert_box(TypeBox::new("lolka")).unwrap(), "test");
+    assert_eq!(*(*map.insert_box(TypeBox::new("lolka")).unwrap()).downcast_ref::<&'static str>().unwrap(), "test");
     assert_eq!(*map.get::<&'static str>().unwrap(), "lolka");
 
     let str_box = map.remove_box(TypeId::of::<&'static str>()).unwrap();
-    assert_eq!(map.remove_box(TypeId::of::<&'static str>()), None);
+    assert!(map.remove_box(TypeId::of::<&'static str>()).is_none());
     assert_eq!(str_box.boxed_type_id(), TypeId::of::<&'static str>());
     let str_box = str_box.into_inner_downcast::<bool>().unwrap_err();
     assert_eq!(str_box.into_inner_downcast::<&'static str>().unwrap(), "lolka");


### PR DESCRIPTION
adds `TypeBox` which is simply a wrapper for `Box<dyn Any + Send + Sync>` which prevents the need for `as` casts (could also do `type TypeBox = Box<dyn Any + Send + Sync>`), and adds the ability to add and remove `TypeBox` directly so that you can don't need to know the object's type at compile time to add or remove it from the map.